### PR TITLE
Add shebang to winSuperMem.py

### DIFF
--- a/winSuperMem.py
+++ b/winSuperMem.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################################
 ## SuperMem for Windows Memory Analysis v1.0
 ## Written by James Lovato - CrowdStrike


### PR DESCRIPTION
Running `./winSuperMem.py` hits `import` as the first non-comment line. Without a shebang, this will often run the ImageMagick `import` tool thinking that `winSuperMem.py` is a shell script, causing the script to apparently stall execution. Adding the sheban~~d~~g will fix this.